### PR TITLE
Adding zephyr cmake targets

### DIFF
--- a/middleware_sdmmc_host_usdhc_zephyr.cmake
+++ b/middleware_sdmmc_host_usdhc_zephyr.cmake
@@ -6,7 +6,7 @@ target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/host/usdhc/blocking/fsl_sdmmc_host.c
 )
 
-target_include_directories(${MCUX_SDK_PROJECT_NAME} PRIVATE
+target_include_directories(${MCUX_SDK_PROJECT_NAME} PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/host/usdhc
 )
 

--- a/middleware_sdmmc_host_usdhc_zephyr.cmake
+++ b/middleware_sdmmc_host_usdhc_zephyr.cmake
@@ -1,0 +1,16 @@
+#Description: Middleware sdmmc host usdhc freertos; user_visible: True
+include_guard(GLOBAL)
+message("middleware_sdmmc_host_usdhc_zephyr component is included.")
+
+target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/host/usdhc/blocking/fsl_sdmmc_host.c
+)
+
+target_include_directories(${MCUX_SDK_PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/host/usdhc
+)
+
+
+include(driver_usdhc)
+include(middleware_sdmmc_osa_zephyr)
+include(middleware_sdmmc_common)

--- a/middleware_sdmmc_osa_zephyr.cmake
+++ b/middleware_sdmmc_osa_zephyr.cmake
@@ -1,0 +1,14 @@
+#Description: SDMMC common stack; user_visible: True
+include_guard(GLOBAL)
+message("middleware_sdmmc_osa_zephyr component is included.")
+
+target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/osa/fsl_sdmmc_osa.c
+)
+
+target_include_directories(${MCUX_SDK_PROJECT_NAME} PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/osa
+)
+
+
+include(component_osa_zephyr)


### PR DESCRIPTION
Similar to [middleware_sdmmc_host_usdhc_polling.cmake](https://github.com/whisperai/mcux-sdk-middleware-sdmmc/blob/main/middleware_sdmmc_host_usdhc_polling.cmake) and [middleware_sdmmc_osa_bm.cmake](https://github.com/whisperai/mcux-sdk-middleware-sdmmc/blob/main/middleware_sdmmc_osa_bm.cmake) for bare metal, it adds `middleware_sdmmc_host_usdhc_zephyr.cmake` and `middleware_sdmmc_osa_zephyr.cmake` for zephyr builds.